### PR TITLE
Bump the gradle-dependencies group with 4 updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,9 +69,9 @@ dependencies {
     implementation("dev.langchain4j:langchain4j-chroma:$lg4j_version")
 //    implementation("dev.langchain4j:langchain4j-mcp:$lg4j_version")
     implementation("dev.langchain4j:langchain4j-reactor:$lg4j_version")
-    implementation("software.amazon.awssdk:sts:2.32.19")
-    implementation("software.amazon.awssdk:sso:2.32.19")
-    implementation("software.amazon.awssdk:ssooidc:2.32.19")
+    implementation("software.amazon.awssdk:sts:2.32.21")
+    implementation("software.amazon.awssdk:sso:2.32.21")
+    implementation("software.amazon.awssdk:ssooidc:2.32.21")
 
     // Retrofit dependencies
     implementation("com.squareup.retrofit2:converter-gson:3.0.0")
@@ -84,7 +84,7 @@ dependencies {
     // JTokkit dependencies
     implementation("com.knuddels:jtokkit:1.1.0")
     implementation("org.commonmark:commonmark:0.25.1")
-    implementation("io.netty:netty-all:4.2.3.Final")
+    implementation("io.netty:netty-all:4.2.4.Final")
 
     // Logging
     implementation("ch.qos.logback:logback-classic:1.5.18")


### PR DESCRIPTION
Bumps the gradle-dependencies group with 4 updates: software.amazon.awssdk:sts, software.amazon.awssdk:sso, software.amazon.awssdk:ssooidc and [io.netty:netty-all](https://github.com/netty/netty).


Updates `software.amazon.awssdk:sts` from 2.32.19 to 2.32.21

Updates `software.amazon.awssdk:sso` from 2.32.19 to 2.32.21

Updates `software.amazon.awssdk:ssooidc` from 2.32.19 to 2.32.21

Updates `io.netty:netty-all` from 4.2.3.Final to 4.2.4.Final
- [Commits](https://github.com/netty/netty/compare/netty-4.2.3.Final...netty-4.2.4.Final)

---
updated-dependencies:
- dependency-name: software.amazon.awssdk:sts dependency-version: 2.32.21 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: gradle-dependencies
- dependency-name: software.amazon.awssdk:sso dependency-version: 2.32.21 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: gradle-dependencies
- dependency-name: software.amazon.awssdk:ssooidc dependency-version: 2.32.21 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: gradle-dependencies
- dependency-name: io.netty:netty-all dependency-version: 4.2.4.Final dependency-type: direct:production update-type: version-update:semver-patch dependency-group: gradle-dependencies ...